### PR TITLE
Remove unused comment tag

### DIFF
--- a/_includes/swc/syllabus.html
+++ b/_includes/swc/syllabus.html
@@ -22,7 +22,7 @@
       <li><a href="{{site.swc_pages}}/r-novice-gapminder/reference">Reference...</a></li>
     </ul>
   </div>
-  -->
+
   <!--
   <div class="col-md-6">
     <h3 id="syllabus-matlab">Programming in MATLAB</h3>


### PR DESCRIPTION
An opening comment tag was removed to show the R programming syllabus, but the closing tag wasn't removed. I removed it for a small cleanup because the `-->` was showing on the github pages site. 